### PR TITLE
[Harvester] parse iso8601 compliant timestamps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       image: openknowledge/ckan-dev:2.10
     services:
       solr:
-        image: ckan/ckan-solr-dev:2.10
+        image: ckan/ckan-solr:2.10-solr9
       postgres:
         image: ckan/ckan-postgres-dev:2.10
         env:

--- a/ckanext/fairdatapoint/profiles.py
+++ b/ckanext/fairdatapoint/profiles.py
@@ -3,12 +3,20 @@
 #  check for multiple-text fields in the schema
 # All changes are © Stichting Health-RI and are licensed under the AGPLv3 license
 
+from datetime import datetime
+import re
+import json
+import logging
+
 from ckanext.dcat.profiles import EuropeanDCATAP2Profile
 from ckan.plugins import toolkit
 from ckan import model
-import json
-from typing import Dict
+import dateutil.parser as dateparser
+from dateutil.parser import ParserError
+from typing import Dict, List
 from rdflib import URIRef
+
+log = logging.getLogger(__name__)
 
 
 def _convert_extras_to_declared_schema_fields(dataset_dict: Dict) -> Dict:
@@ -31,17 +39,50 @@ def _convert_extras_to_declared_schema_fields(dataset_dict: Dict) -> Dict:
     # Populate the declared schema fields, if they are present in the extras
     for extra_dict in dataset_dict.get('extras', []):
         field_key = extra_dict.get('key')
+        field_value = extra_dict.get('value')
         if field_key in dataset_fields:
             preset = dataset_fields[field_key]
-            if preset == "multiple_text" and extra_dict.get('value'):
-                dataset_dict[field_key] = json.loads(extra_dict.get('value'))
+            if preset == 'multiple_text' and field_value:
+                dataset_dict[field_key] = json.loads(field_value)
+            elif preset == 'date' and field_value:
+                dataset_dict[field_key] = convert_datetime_string(field_value)
             else:
-                dataset_dict[field_key] = extra_dict.get('value')
+                dataset_dict[field_key] = field_value
 
     # Remove the extras that have been populated into the declared schema fields
     dataset_dict['extras'] = [d for d in dataset_dict['extras'] if d.get('key') not in dataset_fields]
 
     return dataset_dict
+
+
+def validate_tags(values_list: List[Dict]) -> List:
+    """
+    Validates tags strings to contain allowed characters, replaces others with spaces
+    """
+    illegal_pattern = re.compile('[^A-Za-z0-9\- _\.]')
+    tags = []
+    for item in values_list:
+        tag_value = item['name']
+        find_illegal = re.search(illegal_pattern, tag_value)
+        if find_illegal:
+            log.warning(f'Tag {tag_value} contains values other than alphanumeric characters, spaces, hyphens, '
+                        f'underscores or dots, they will be replaces with spaces')
+            tag = {'name': re.sub(illegal_pattern, ' ', tag_value)}
+            tags.append(tag)
+        else:
+            tags.append(item)
+    return tags
+
+
+def convert_datetime_string(date_value: str) -> datetime:
+    """
+    Converts datestrings (e.g. '2023-10-06T10:12:55.614000+00:00') to datetime class instance
+    """
+    try:
+        date_value = dateparser.parse(date_value)
+    except ParserError:
+        log.error('A date field string value can not be parsed to a date')
+    return date_value
 
 
 class FAIRDataPointDCATAPProfile(EuropeanDCATAP2Profile):
@@ -54,10 +95,12 @@ class FAIRDataPointDCATAPProfile(EuropeanDCATAP2Profile):
 
         dataset_dict = _convert_extras_to_declared_schema_fields(dataset_dict)
 
+        dataset_dict['tags'] = validate_tags(dataset_dict['tags'])
+
         # Example of adding a field
-        dataset_dict['extras'].append({'key': 'hello',
-                                       'value': "Hello from the FAIR data point profile. Use this function to do "
-                                                "FAIR data point specific stuff during the import stage"})
+        # dataset_dict['extras'].append({'key': 'hello',
+        #                                'value': 'Hello from the FAIR data point profile. Use this function to do '
+        #                                         'FAIR data point specific stuff during the import stage'})
 
         return dataset_dict
 

--- a/ckanext/fairdatapoint/tests/test_data/dataset_cbioportal.ttl
+++ b/ckanext/fairdatapoint/tests/test_data/dataset_cbioportal.ttl
@@ -1,0 +1,66 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ldp: <http://www.w3.org/ns/ldp#> .
+@prefix ns1: <https://w3id.org/fdp/fdp-o#> .
+@prefix ns2: <http://semanticscience.org/resource/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://health-ri.sandbox.semlab-leiden.nl/distribution/> a ldp:DirectContainer ;
+    dcterms:title "Distributions" ;
+    ldp:contains <https://health-ri.sandbox.semlab-leiden.nl/distribution/931ed9c4-ad23-47ff-b121-2eb428e57423>,
+        <https://health-ri.sandbox.semlab-leiden.nl/distribution/ad00299f-6efb-42aa-823d-5ff2337f38f7> ;
+    ldp:hasMemberRelation dcat:distribution ;
+    ldp:membershipResource <https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5> .
+
+<https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5> a dcat:Dataset,
+        dcat:Resource ;
+    rdfs:label "[PUBLIC] Low-Grade Gliomas (UCSF, Science 2014)" ;
+    dcterms:accessRights <https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5#accessRights> ;
+    dcterms:conformsTo <https://health-ri.sandbox.semlab-leiden.nl/profile/2f08228e-1789-40f8-84cd-28e3288c3604> ;
+    dcterms:description "Whole exome sequencing of 23 grade II glioma tumor/normal pairs." ;
+    dcterms:identifier "lgg_ucsf_2014"^^xsd:token ;
+    dcterms:isPartOf <https://health-ri.sandbox.semlab-leiden.nl/catalog/5c85cb9f-be4a-406c-ab0a-287fa787caa0> ;
+    dcterms:isReferencedBy <https://pubmed.ncbi.nlm.nih.gov/24336570> ;
+    dcterms:issued "2019-10-30 23:00:00" ;
+    dcterms:language <http://id.loc.gov/vocabulary/iso639-1/en> ;
+    dcterms:license <http://rdflicense.appspot.com/rdflicense/cc-by-nc-nd3.0> ;
+    dcterms:modified "2019-10-30 23:00:00" ;
+    dcterms:publisher <https://www.health-ri.nl> ;
+    dcterms:temporal [ a dcterms:PeriodOfTime ] ;
+    dcterms:title "[PUBLIC] Low-Grade Gliomas (UCSF, Science 2014)" ;
+    ns2:SIO_000628 <https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5/metrics/445c0a70d1e214e545b261559e2842f4>,
+        <https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5/metrics/5d27e854a9e78eb3f663331cd47cdc13> ;
+    dcat:distribution <https://health-ri.sandbox.semlab-leiden.nl/distribution/931ed9c4-ad23-47ff-b121-2eb428e57423>,
+        <https://health-ri.sandbox.semlab-leiden.nl/distribution/ad00299f-6efb-42aa-823d-5ff2337f38f7> ;
+    dcat:keyword "CNS/Brain",
+        "Diffuse Glioma",
+        "Glioma" ;
+    dcat:landingPage <https://cbioportal.health-ri.nl/study/summary?id=lgg_ucsf_2014> ;
+    ns1:metadataIdentifier <https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5#identifier> ;
+    ns1:metadataIssued "2024-01-22T12:58:04.249592+00:00"^^xsd:dateTime ;
+    ns1:metadataModified "2024-01-22T12:58:05.109355+00:00"^^xsd:dateTime .
+
+<https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5#accessRights> a dcterms:RightsStatement ;
+    dcterms:description "This resource has no access restriction" .
+
+<https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5#identifier> a <http://purl.org/spar/datacite/Identifier> ;
+    dcterms:identifier "https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5" .
+
+<https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5/metrics/445c0a70d1e214e545b261559e2842f4> ns2:SIO_000332 <https://www.ietf.org/rfc/rfc3986.txt> ;
+    ns2:SIO_000628 <https://www.ietf.org/rfc/rfc3986.txt> .
+
+<https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5/metrics/5d27e854a9e78eb3f663331cd47cdc13> ns2:SIO_000332 <https://www.wikidata.org/wiki/Q8777> ;
+    ns2:SIO_000628 <https://www.wikidata.org/wiki/Q8777> .
+
+<https://health-ri.sandbox.semlab-leiden.nl/profile/2f08228e-1789-40f8-84cd-28e3288c3604> rdfs:label "Dataset Profile" .
+
+<https://health-ri.sandbox.semlab-leiden.nl/distribution/931ed9c4-ad23-47ff-b121-2eb428e57423> dcterms:description "Clinical data for [PUBLIC] Low-Grade Gliomas (UCSF, Science 2014)" ;
+    dcterms:license <http://rdflicense.appspot.com/rdflicense/cc-by-nc-nd3.0> ;
+    dcterms:title "Clinical data for [PUBLIC] Low-Grade Gliomas (UCSF, Science 2014)" ;
+    dcat:accessURL <https://cbioportal.health-ri.nl/study/clinicalData?id=lgg_ucsf_2014> .
+
+<https://health-ri.sandbox.semlab-leiden.nl/distribution/ad00299f-6efb-42aa-823d-5ff2337f38f7> dcterms:description "Mutation data from whole exome sequencing of 23 grade II glioma tumor/normal pairs. (MAF)" ;
+    dcterms:license <http://rdflicense.appspot.com/rdflicense/cc-by-nc-nd3.0> ;
+    dcterms:title "Mutations" ;
+    dcat:accessURL <https://cbioportal.health-ri.nl/study/summary?id=lgg_ucsf_2014> .

--- a/ckanext/fairdatapoint/tests/test_processors.py
+++ b/ckanext/fairdatapoint/tests/test_processors.py
@@ -17,6 +17,8 @@
 """
 
 import pytest
+from datetime import datetime
+from dateutil.tz import tzutc
 from pathlib import Path
 from unittest.mock import patch
 from rdflib import Graph
@@ -59,10 +61,7 @@ class TestProcessors:
             record=data)
         expected_dataset = {"extras":
             [
-                {"key": "uri", "value": "https://covid19initiatives.health-ri.nl/p/Project/27866022694497978"},
-                {"key": "hello",
-                 "value": "Hello from the FAIR data point profile. Use this function to do FAIR data point "
-                          "specific stuff during the import stage"}
+                {"key": "uri", "value": "https://covid19initiatives.health-ri.nl/p/Project/27866022694497978"}
             ],
             "resources": [],
             "title": "COVID-NL cohort MUMC+",
@@ -73,8 +72,8 @@ class TestProcessors:
             "has_version": ["https://repo.metadatacenter.org/template-instances/2836bf1c-76e9-44e7-a65e-80e9ca63025a"],
             "contact_uri": "https://orcid.org/0000-0002-4348-707X",
             "publisher_uri": "https://opal.health-ri.nl/pub/",
-            "temporal_start": "2020-01-01",
-            "temporal_end": "2025-12-31"}
+            "temporal_start": datetime(2020, 1, 1, 0, 0),
+            "temporal_end": datetime(2025, 12, 31, 0, 0)}
         assert actual_dataset == expected_dataset
 
     def test_fdp_record_converter_catalog_dict(self):
@@ -84,25 +83,22 @@ class TestProcessors:
             guid="catalog=https://fair.healthinformationportal.eu/catalog/1c75c2c9-d2cc-44cb-aaa8-cf8c11515c8d",
             record=data)
         expected = {
-                       "access_rights": "https://fair.healthinformationportal.eu/catalog/"
-                                        "1c75c2c9-d2cc-44cb-aaa8-cf8c11515c8d#accessRights",
-                       "conforms_to": ["https://fair.healthinformationportal.eu/profile/"
-                                      "a0949e72-4466-4d53-8900-9436d1049a4b"],
-                       "extras": [{"key": "uri",
-                                   "value": "https://fair.healthinformationportal.eu/catalog/"
-                                            "1c75c2c9-d2cc-44cb-aaa8-cf8c11515c8d"},
-                                  {"key": "hello",
-                                   "value": "Hello from the FAIR data point profile. Use this "
-                                            "function to do FAIR data point specific stuff during "
-                                            "the import stage"}],
-                       "has_version": ["1.0"],
-                       "issued": "2023-10-06T10:12:55.614000+00:00",
-                       "language": ["http://id.loc.gov/vocabulary/iso639-1/en"],
-                       "license_id": "",
-                       "modified": "2023-10-06T10:12:55.614000+00:00",
-                       "publisher_name": "Automatic",
-                       "resources": [],
-                       "tags": [],
-                       "title": "Slovenia National Node"
+            "access_rights": "https://fair.healthinformationportal.eu/catalog/"
+                             "1c75c2c9-d2cc-44cb-aaa8-cf8c11515c8d#accessRights",
+            "conforms_to": ["https://fair.healthinformationportal.eu/profile/"
+                            "a0949e72-4466-4d53-8900-9436d1049a4b"],
+            "extras": [{"key": "uri",
+                        "value": "https://fair.healthinformationportal.eu/catalog/"
+                                 "1c75c2c9-d2cc-44cb-aaa8-cf8c11515c8d"},
+                       ],
+            "has_version": ["1.0"],
+            "issued": datetime(2023, 10, 6, 10, 12, 55, 614000, tzinfo=tzutc()),
+            "language": ["http://id.loc.gov/vocabulary/iso639-1/en"],
+            "license_id": "",
+            "modified": datetime(2023, 10, 6, 10, 12, 55, 614000, tzinfo=tzutc()),
+            "publisher_name": "Automatic",
+            "resources": [],
+            "tags": [],
+            "title": "Slovenia National Node"
         }
         assert actual == expected

--- a/ckanext/fairdatapoint/tests/test_profiles.py
+++ b/ckanext/fairdatapoint/tests/test_profiles.py
@@ -1,0 +1,101 @@
+"""
+    CKAN Fair Data Point extension Test Suite
+    Copyright (C) 2024, Stichting Health-RI
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import pytest
+from datetime import datetime
+from dateutil.tz import tzutc, tzoffset
+from pathlib import Path
+from rdflib import Graph, URIRef
+from ckanext.fairdatapoint.profiles import validate_tags, convert_datetime_string, FAIRDataPointDCATAPProfile
+from ckanext.fairdatapoint.harvesters.domain.fair_data_point_record_to_package_converter import (
+    FairDataPointRecordToPackageConverter)
+
+TEST_DATA_DIRECTORY = Path(Path(__file__).parent.resolve(), "test_data")
+
+
+@pytest.mark.parametrize("input_tags,expected_tags", [
+    ([{"name": "CNS/Brain"}], [{"name": "CNS Brain"}]),
+    ([{"name": "COVID-19"}, {"name": "3`-DNA"}], [{"name": "COVID-19"}, {"name": "3 -DNA"}]),
+    ([{"name": "something-1.1"}, {"name": "breast cancer"}], [{"name": "something-1.1"}, {"name": "breast cancer"}]),
+    ([], [])
+])
+def test_validate_tags(input_tags, expected_tags):
+    actual_tags = validate_tags(input_tags)
+    assert actual_tags == expected_tags
+
+
+@pytest.mark.ckan_config("ckan.plugins", "scheming_datasets")
+@pytest.mark.usefixtures("with_plugins")
+def test_parse_dataset():
+    """Dataset with keywords which should be modified"""
+    fdp_record_to_package = FairDataPointRecordToPackageConverter(profile="fairdatapoint_dcat_ap")
+    data = Graph().parse(Path(TEST_DATA_DIRECTORY, "dataset_cbioportal.ttl")).serialize()
+    actual = fdp_record_to_package.record_to_package(
+        guid="catalog=https://health-ri.sandbox.semlab-leiden.nl/catalog/5c85cb9f-be4a-406c-ab0a-287fa787caa0;"
+             "dataset=https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5",
+        record=data)
+    expected = {
+        'extras': [
+            {'key': 'uri',
+             'value': 'https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5'
+             }
+        ],
+        'resources': [{'name': 'Clinical data for [PUBLIC] Low-Grade Gliomas (UCSF, Science 2014)',
+                       'description': 'Clinical data for [PUBLIC] Low-Grade Gliomas (UCSF, Science 2014)',
+                       'access_url': 'https://cbioportal.health-ri.nl/study/clinicalData?id=lgg_ucsf_2014',
+                       'license': 'http://rdflicense.appspot.com/rdflicense/cc-by-nc-nd3.0',
+                       'url': 'https://cbioportal.health-ri.nl/study/clinicalData?id=lgg_ucsf_2014',
+                       'uri': 'https://health-ri.sandbox.semlab-leiden.nl/distribution/'
+                              '931ed9c4-ad23-47ff-b121-2eb428e57423',
+                       'distribution_ref': 'https://health-ri.sandbox.semlab-leiden.nl/distribution/'
+                                           '931ed9c4-ad23-47ff-b121-2eb428e57423'},
+                      {'name': 'Mutations',
+                       'description': 'Mutation data from whole exome sequencing of 23 grade II glioma tumor/normal '
+                                      'pairs. (MAF)',
+                       'access_url': 'https://cbioportal.health-ri.nl/study/summary?id=lgg_ucsf_2014',
+                       'license': 'http://rdflicense.appspot.com/rdflicense/cc-by-nc-nd3.0',
+                       'url': 'https://cbioportal.health-ri.nl/study/summary?id=lgg_ucsf_2014',
+                       'uri': 'https://health-ri.sandbox.semlab-leiden.nl/distribution/'
+                              'ad00299f-6efb-42aa-823d-5ff2337f38f7',
+                       'distribution_ref': 'https://health-ri.sandbox.semlab-leiden.nl/distribution/'
+                                           'ad00299f-6efb-42aa-823d-5ff2337f38f7'}],
+        'title': '[PUBLIC] Low-Grade Gliomas (UCSF, Science 2014)',
+        'notes': 'Whole exome sequencing of 23 grade II glioma tumor/normal pairs.',
+        'url': 'https://cbioportal.health-ri.nl/study/summary?id=lgg_ucsf_2014',
+        'tags': [{'name': 'CNS Brain'}, {'name': 'Diffuse Glioma'}, {'name': 'Glioma'}], 'license_id': '',
+        'issued': datetime(2019, 10, 30, 23, 0),
+        'modified': datetime(2019, 10, 30, 23, 0),
+        'identifier': 'lgg_ucsf_2014', 'language': ['http://id.loc.gov/vocabulary/iso639-1/en'],
+        'conforms_to': ['https://health-ri.sandbox.semlab-leiden.nl/profile/2f08228e-1789-40f8-84cd-28e3288c3604'],
+        'publisher_uri': 'https://www.health-ri.nl',
+        'access_rights': 'https://health-ri.sandbox.semlab-leiden.nl/dataset/'
+                         'd9956191-1aff-4181-ac8b-16b829135ed5#accessRights',
+        'is_referenced_by': '["https://pubmed.ncbi.nlm.nih.gov/24336570"]'}
+    assert actual == expected
+
+
+@pytest.mark.parametrize("input_timestring,expected_output", [
+    ("2023-10-06T10:12:55.614000+00:00",
+     datetime(2023, 10, 6, 10, 12, 55, 614000, tzinfo=tzutc())),
+    ("2024-02-15 11:16:37+03:00",
+     datetime(2024, 2, 5, 11, 16, 37, tzinfo=tzoffset(None, 10800))),
+    ("November 9, 1999", datetime(1999, 11, 9, 0, 0, 0)),
+    ("2006-09", datetime(2006, 9, 18))])
+def test_convert_datetime_string(input_timestring, expected_output):
+    actual = convert_datetime_string(input_timestring)
+    assert actual == expected_output

--- a/ckanext/fairdatapoint/tests/test_profiles.py
+++ b/ckanext/fairdatapoint/tests/test_profiles.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from dateutil.tz import tzutc, tzoffset
 from pathlib import Path
 from rdflib import Graph, URIRef
-from ckanext.fairdatapoint.profiles import validate_tags, convert_datetime_string, FAIRDataPointDCATAPProfile
+from ckanext.fairdatapoint.profiles import validate_tags, convert_datetime_string
 from ckanext.fairdatapoint.harvesters.domain.fair_data_point_record_to_package_converter import (
     FairDataPointRecordToPackageConverter)
 
@@ -93,7 +93,7 @@ def test_parse_dataset():
     ("2023-10-06T10:12:55.614000+00:00",
      datetime(2023, 10, 6, 10, 12, 55, 614000, tzinfo=tzutc())),
     ("2024-02-15 11:16:37+03:00",
-     datetime(2024, 2, 5, 11, 16, 37, tzinfo=tzoffset(None, 10800))),
+     datetime(2024, 2, 15, 11, 16, 37, tzinfo=tzoffset(None, 10800))),
     ("November 9, 1999", datetime(1999, 11, 9, 0, 0, 0)),
     ("2006-09", datetime(2006, 9, 18))])
 def test_convert_datetime_string(input_timestring, expected_output):


### PR DESCRIPTION
fix time format: CKAN could not convert timesharing to date time if timezone is in the timestring
add tags validation: characters other than alphanumeric, dots, spaces, hyphens and underscores are replaced with spaces.
comment out example adding `hello` field to each dataset 