### PR TITLE
Resolve labels during harvesting

### DIFF
--- a/ckanext/fairdatapoint/fair_data_point_main.py
+++ b/ckanext/fairdatapoint/fair_data_point_main.py
@@ -5,24 +5,26 @@
 
 # coding: utf8
 
-from ckanext.fairdatapoint.harvesters.domain.fair_data_point_record_provider import FairDataPointRecordProvider
+from ckanext.fairdatapoint.harvesters.domain.fair_data_point_record_provider import (
+    FairDataPointRecordProvider,
+)
 
 
 def main():
     endpoints = [
-        'https://fair.healthinformationportal.eu',
-        'https://health-ri.sandbox.semlab-leiden.nl/',
-        'https://portal-gdi-nl.molgeniscloud.org/api/fdp/'
+        "https://fair.healthinformationportal.eu",
+        "https://health-ri.sandbox.semlab-leiden.nl/",
+        "https://portal-gdi-nl.molgeniscloud.org/api/fdp/",
     ]
 
     for endpoint in endpoints:
-        print('!@#$%^&*()_+', endpoint, '+_)(*&^%$#@!')
+        print("!@#$%^&*()_+", endpoint, "+_)(*&^%$#@!")
         record_provider = FairDataPointRecordProvider(endpoint)
 
         record_ids = record_provider.get_record_ids()
         for record_id in record_ids:
             print(record_id)
-            if 'dataset=' in record_id:
+            if "dataset=" in record_id:
                 data = record_provider.get_record_by_id(record_id)
                 print(data)
                 break

--- a/ckanext/fairdatapoint/harvesters/civity_harvester.py
+++ b/ckanext/fairdatapoint/harvesters/civity_harvester.py
@@ -14,6 +14,11 @@ from abc import abstractmethod
 import ckan.plugins.toolkit as toolkit
 from ckan import model
 
+from ckanext.fairdatapoint.resolver import (
+    get_list_unresolved_terms,
+    label_resolver,
+    terms_in_package_dict,
+)
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject
 from ckanext.harvest.model import HarvestObjectExtra as HOExtra
@@ -21,6 +26,9 @@ from ckanext.harvest.model import HarvestObjectExtra as HOExtra
 ID = "id"
 
 log = logging.getLogger(__name__)
+
+# TODO move this to be a harvester setting
+RESOLVE_LABELS = True
 
 
 def text_traceback():
@@ -400,6 +408,32 @@ class CivityHarvester(HarvesterBase):
                 resources, package_id, package_dict["title"], context, harvest_object
             ):
                 return False
+            # Also update labels in case of success
+            if RESOLVE_LABELS:
+                log.debug("Label resolving is requested")
+                translation_list = []
+                total_terms = terms_in_package_dict(package_dict)
+                unresolved_terms = get_list_unresolved_terms(total_terms)
+                if unresolved_terms:
+                    log.debug("There are %d unresolved terms", len(unresolved_terms))
+
+                    resolver = label_resolver()
+                    for term in unresolved_terms:
+                        extra_translations = resolver.load_and_translate_uri(term)
+                        translation_list.extend(extra_translations)
+
+                    log.debug("Resolved %d labels", len(translation_list))
+
+                    # Check if there is actually translations in the list
+                    if translation_list:
+                        # term_translation_update is a privileged function
+                        # Thank god CKAN is like Hollywood OS and we can just override
+                        toolkit.get_action("term_translation_update_many")(
+                            {"ignore_auth": True, "defer_commit": True},
+                            {"data": translation_list},
+                        )
+                else:
+                    log.debug("There are no unresolved terms!")
         else:
             return False
 

--- a/ckanext/fairdatapoint/harvesters/civity_harvester.py
+++ b/ckanext/fairdatapoint/harvesters/civity_harvester.py
@@ -5,21 +5,20 @@
 
 import cgitb
 import json
+import logging
 import sys
 import uuid
 import warnings
 from abc import abstractmethod
 
-from ckan import model
 import ckan.plugins.toolkit as toolkit
+from ckan import model
 
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject
 from ckanext.harvest.model import HarvestObjectExtra as HOExtra
-import logging
 
-
-ID = 'id'
+ID = "id"
 
 log = logging.getLogger(__name__)
 
@@ -27,8 +26,8 @@ log = logging.getLogger(__name__)
 def text_traceback():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        res = 'the original traceback:'.join(
-            cgitb.text(sys.exc_info()).split('the original traceback:')[1:]
+        res = "the original traceback:".join(
+            cgitb.text(sys.exc_info()).split("the original traceback:")[1:]
         ).strip()
     return res
 
@@ -43,6 +42,7 @@ class CivityHarvester(HarvesterBase):
     the harvester specific work to a RecordProvider (to access records from a harvest source) and a
     RecordToPackageConverter to convert proprietary data from the harvest source to CKAN packages.
     """
+
     record_provider = None
 
     record_to_package_converter = None
@@ -76,14 +76,16 @@ class CivityHarvester(HarvesterBase):
         :returns: A list of HarvestObject ids
         """
 
-        logger = logging.getLogger(__name__ + '.gather_stage')
+        logger = logging.getLogger(__name__ + ".gather_stage")
 
-        logger.debug('Starting gather_stage for job: [%r]', harvest_job)
+        logger.debug("Starting gather_stage for job: [%r]", harvest_job)
 
         #
         result = []
 
-        self.setup_record_provider(harvest_job.source.url, self._get_harvest_config(harvest_job.source.config))
+        self.setup_record_provider(
+            harvest_job.source.url, self._get_harvest_config(harvest_job.source.config)
+        )
 
         guids_to_package_ids = self._get_guids_to_package_ids_from_database(harvest_job)
 
@@ -100,7 +102,7 @@ class CivityHarvester(HarvesterBase):
                 obj = HarvestObject(
                     guid=guid,
                     job=harvest_job,
-                    extras=[HOExtra(key='status', value='new')]
+                    extras=[HOExtra(key="status", value="new")],
                 )
                 obj.save()
                 result.append(obj.id)
@@ -109,7 +111,7 @@ class CivityHarvester(HarvesterBase):
                     guid=guid,
                     job=harvest_job,
                     package_id=guids_to_package_ids[guid],
-                    extras=[HOExtra(key='status', value='change')]
+                    extras=[HOExtra(key="status", value="change")],
                 )
                 obj.save()
                 result.append(obj.id)
@@ -118,14 +120,14 @@ class CivityHarvester(HarvesterBase):
                     guid=guid,
                     job=harvest_job,
                     package_id=guids_to_package_ids[guid],
-                    extras=[HOExtra(key='status', value='delete')]
+                    extras=[HOExtra(key="status", value="delete")],
                 )
                 # TODO
                 #  Deleted object is marked as not being current here already. When the actual deletion of the package
                 #  fails in the import stage, an orphan package will remain in existence and never be deleted.
-                model.Session.query(HarvestObject). \
-                    filter_by(guid=guid). \
-                    update({'current': False}, False)
+                model.Session.query(HarvestObject).filter_by(guid=guid).update(
+                    {"current": False}, False
+                )
                 obj.save()
                 result.append(obj.id)
 
@@ -133,7 +135,7 @@ class CivityHarvester(HarvesterBase):
         # if len(result) == 0:
         #     result = None
 
-        logger.debug('Finished gather_stage for job: [%r]', harvest_job)
+        logger.debug("Finished gather_stage for job: [%r]", harvest_job)
 
         return result
 
@@ -156,18 +158,21 @@ class CivityHarvester(HarvesterBase):
                   all, False if not successful
         """
 
-        logger = logging.getLogger(__name__ + '.fetch_stage')
+        logger = logging.getLogger(__name__ + ".fetch_stage")
 
-        logger.debug('Starting fetch_stage for harvest object [%s]', harvest_object.id)
+        logger.debug("Starting fetch_stage for harvest object [%s]", harvest_object.id)
 
-        self.setup_record_provider(harvest_object.source.url, self._get_harvest_config(harvest_object.source.config))
+        self.setup_record_provider(
+            harvest_object.source.url,
+            self._get_harvest_config(harvest_object.source.config),
+        )
 
         result = False
 
         # Check harvest object status
-        status = self._get_object_extra(harvest_object, 'status')
+        status = self._get_object_extra(harvest_object, "status")
 
-        if status == 'delete':
+        if status == "delete":
             # No need to fetch anything, just pass to the import stage
             result = True
 
@@ -183,32 +188,38 @@ class CivityHarvester(HarvesterBase):
                         harvest_object.save()
                     except Exception as e:
                         self._save_object_error(
-                            'Error saving harvest object for identifier [%s] [%r]' % (identifier, e),
-                            harvest_object
+                            "Error saving harvest object for identifier [%s] [%r]"
+                            % (identifier, e),
+                            harvest_object,
                         )
                         return False
 
                     model.Session.commit()
 
                     logger.debug(
-                        'Record content saved for ID [%s], harvest object ID [%s]',
+                        "Record content saved for ID [%s], harvest object ID [%s]",
                         harvest_object.guid,
-                        harvest_object.id
+                        harvest_object.id,
                     )
 
                     result = True
                 else:
-                    self._save_object_error('Empty record for identifier %s' % identifier, harvest_object)
+                    self._save_object_error(
+                        "Empty record for identifier %s" % identifier, harvest_object
+                    )
                     result = False
 
-            except Exception as e:  # Broad exception because of unpredictability of Exceptions
+            except (
+                Exception
+            ) as e:  # Broad exception because of unpredictability of Exceptions
                 self._save_object_error(
-                    'Error getting the record with identifier [%s] from record provider' % identifier,
-                    harvest_object
+                    "Error getting the record with identifier [%s] from record provider"
+                    % identifier,
+                    harvest_object,
                 )
                 result = False
 
-        logger.debug('Finished fetch_stage for harvest object [%s]', harvest_object.id)
+        logger.debug("Finished fetch_stage for harvest object [%s]", harvest_object.id)
 
         return result
 
@@ -239,40 +250,57 @@ class CivityHarvester(HarvesterBase):
                   need harvesting after all or False if there were errors.
         """
 
-        logger = logging.getLogger(__name__ + '.import_stage')
+        logger = logging.getLogger(__name__ + ".import_stage")
 
-        logger.debug('Starting import stage for harvest_object [%s]', harvest_object.id)
+        logger.debug("Starting import stage for harvest_object [%s]", harvest_object.id)
 
         self.setup_record_to_package_converter(
             harvest_object.source.url,
-            self._get_harvest_config(harvest_object.source.config)
+            self._get_harvest_config(harvest_object.source.config),
         )
 
-        status = self._get_object_extra(harvest_object, 'status')
+        status = self._get_object_extra(harvest_object, "status")
 
-        if status == 'delete':
+        if status == "delete":
             # Delete package
-            context = {'model': model, 'session': model.Session, 'user': self._get_user_name()}
+            context = {
+                "model": model,
+                "session": model.Session,
+                "user": self._get_user_name(),
+            }
 
-            toolkit.get_action('package_delete')(context, {ID: harvest_object.package_id})
-            logger.info('Deleted package {0} with guid {1}'.format(harvest_object.package_id, harvest_object.guid))
+            toolkit.get_action("package_delete")(
+                context, {ID: harvest_object.package_id}
+            )
+            logger.info(
+                "Deleted package {0} with guid {1}".format(
+                    harvest_object.package_id, harvest_object.guid
+                )
+            )
 
             return True
 
         if harvest_object.content is None:
-            self._save_object_error('Empty content for object %s' % harvest_object.id, harvest_object, 'Import')
+            self._save_object_error(
+                "Empty content for object %s" % harvest_object.id,
+                harvest_object,
+                "Import",
+            )
             return False
 
         try:
             package_dict = self.record_to_package_converter.record_to_package(
-                harvest_object.guid,
-                str(harvest_object.content)
+                harvest_object.guid, str(harvest_object.content)
             )
         except Exception as e:
-            logger.error('Error converting record to package for identifier [%s] [%r]' % (harvest_object.id, e))
+            logger.error(
+                "Error converting record to package for identifier [%s] [%r]"
+                % (harvest_object.id, e)
+            )
             self._save_object_error(
-                'Error converting record to package for identifier [%s] [%r]' % (harvest_object.id, e),
-                harvest_object
+                "Error converting record to package for identifier [%s] [%r]"
+                % (harvest_object.id, e),
+                harvest_object,
             )
             return False
 
@@ -281,48 +309,59 @@ class CivityHarvester(HarvesterBase):
 
         # TODO Doesn't this mean a new name will be generated for each update? This should be a new which never ever
         #  changes as long as the record in the harvester source does not change
-        logger.info('Generating package name from title [{}]'.format(package_dict['title']))
+        logger.info(
+            "Generating package name from title [{}]".format(package_dict["title"])
+        )
         try:
             # Set name for new package to prevent name conflict, see ckanext-harvest issue #117
             try:
-                package_dict['name'] = self._gen_new_name(package_dict['title'])
+                package_dict["name"] = self._gen_new_name(package_dict["title"])
             except TypeError:
                 logger.error(
-                    'TypeError: error generating package name. Package title {} is not a string'.format(
-                        str(package_dict['title'])))
+                    "TypeError: error generating package name. Package title {} is not a string".format(
+                        str(package_dict["title"])
+                    )
+                )
                 self._save_object_error(
-                    'TypeError: error generating package name. Package title [%s] is not a string.' %
-                    str(package_dict['title']), harvest_object
+                    "TypeError: error generating package name. Package title [%s] is not a string."
+                    % str(package_dict["title"]),
+                    harvest_object,
                 )
                 return False
 
         except toolkit.ValidationError:
             logger.info(
-                'ValidationError: name already exists. Generating new package name from existing name {}'.format(
-                    package_dict['name']))
-            package_dict['name'] = self._gen_new_name(package_dict['name'])
-        logger.info('Generated package name from title [{}]: [{}]'.format(package_dict['title'], package_dict['name']))
+                "ValidationError: name already exists. Generating new package name from existing name {}".format(
+                    package_dict["name"]
+                )
+            )
+            package_dict["name"] = self._gen_new_name(package_dict["name"])
+        logger.info(
+            "Generated package name from title [{}]: [{}]".format(
+                package_dict["title"], package_dict["name"]
+            )
+        )
 
         # Unless already set by an extension, get the owner organization (if any)
         # from the harvest source dataset
-        if not package_dict.get('owner_org'):
+        if not package_dict.get("owner_org"):
             source_dataset = model.Package.get(harvest_object.source.id)
             if source_dataset.owner_org:
-                package_dict['owner_org'] = source_dataset.owner_org
+                package_dict["owner_org"] = source_dataset.owner_org
 
         context = {
-            'user': self._get_user_name(),
-            'return_id_only': True,
-            'ignore_auth': True,
+            "user": self._get_user_name(),
+            "return_id_only": True,
+            "ignore_auth": True,
         }
 
         # Variable for the new or existing package ID
         package_id = None
 
         # Separate Update of package and resources, for trigger reasons
-        resources = package_dict.pop('resources')
+        resources = package_dict.pop("resources")
 
-        if status == 'new':
+        if status == "new":
             # If a package ID has not been assigned by the RecordToPackageConverter...
             if ID not in package_dict.keys():
                 # ... we need to explicitly provide a new package ID.
@@ -335,33 +374,43 @@ class CivityHarvester(HarvesterBase):
             # Defer constraints and flush so the dataset can be indexed with
             # the harvest object id (on the after_show hook from the harvester
             # plugin)
-            model.Session.execute('SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED')
+            model.Session.execute(
+                "SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED"
+            )
             model.Session.flush()
 
             # Create the package in CKAN
-            package_id = self._create_or_update_package(package_dict, 'create', context, harvest_object)
+            package_id = self._create_or_update_package(
+                package_dict, "create", context, harvest_object
+            )
 
-        elif status == 'change':
+        elif status == "change":
             # Updating existing package, if all is well...
             package_dict[ID] = harvest_object.package_id
 
             # Update existing package
-            package_id = self._create_or_update_package(package_dict, 'update', context, harvest_object)
+            package_id = self._create_or_update_package(
+                package_dict, "update", context, harvest_object
+            )
 
         # In case of success (package_id is defined in that case), create the resources
         if package_id:
             # Create resources
-            if not self._create_resources(resources, package_id, package_dict['title'], context, harvest_object):
+            if not self._create_resources(
+                resources, package_id, package_dict["title"], context, harvest_object
+            ):
                 return False
         else:
             return False
 
         # Update harvester bookkeeping
         # Get the last harvested object (if any)
-        previous_object = model.Session.query(HarvestObject) \
-            .filter(HarvestObject.guid == harvest_object.guid) \
-            .filter(HarvestObject.current == True) \
+        previous_object = (
+            model.Session.query(HarvestObject)
+            .filter(HarvestObject.guid == harvest_object.guid)
+            .filter(HarvestObject.current == True)
             .first()
+        )
 
         # Flag previous object as not current anymore
         if previous_object:
@@ -374,46 +423,59 @@ class CivityHarvester(HarvesterBase):
 
         model.Session.commit()
 
-        logger.debug('Finished import stage for harvest_object [%s]', harvest_object.id)
+        logger.debug("Finished import stage for harvest_object [%s]", harvest_object.id)
 
         return True
 
-    def _create_or_update_package(self, package_dict, create_or_update, context, harvest_object):
-        if 'revision_id' in package_dict.keys():
-            package_dict.pop('revision_id')
+    def _create_or_update_package(
+        self, package_dict, create_or_update, context, harvest_object
+    ):
+        if "revision_id" in package_dict.keys():
+            package_dict.pop("revision_id")
 
         try:
-            action = 'package_' + create_or_update
+            action = "package_" + create_or_update
             result = toolkit.get_action(action)(context.copy(), package_dict)
-            log.info('Successful [%s] for package with id [%s]', create_or_update, result)
+            log.info(
+                "Successful [%s] for package with id [%s]", create_or_update, result
+            )
         except toolkit.ValidationError as e:
-            error_message = 'Error in [{}] for package [{}]: [{}]'.format(create_or_update, package_dict['title'], e)
+            error_message = "Error in [{}] for package [{}]: [{}]".format(
+                create_or_update, package_dict["title"], e
+            )
             log.error(error_message)
             self._save_object_error(error_message, harvest_object)
             result = None
 
         return result
 
-    def _create_resources(self, resource_dicts, package_id, package_title, context, harvest_object):
+    def _create_resources(
+        self, resource_dicts, package_id, package_title, context, harvest_object
+    ):
         result = True
 
         for resource_dict in resource_dicts:
-            if 'id' in resource_dict.keys():
-                resource_dict.pop('id')
+            if "id" in resource_dict.keys():
+                resource_dict.pop("id")
 
-            if 'revision_id' in resource_dict.keys():
-                resource_dict.pop('revision_id')
+            if "revision_id" in resource_dict.keys():
+                resource_dict.pop("revision_id")
 
-            resource_dict['package_id'] = package_id
+            resource_dict["package_id"] = package_id
             try:
-                resource_dict = toolkit.get_action('resource_create')(context.copy(), resource_dict)
-                log.info('Created resource with id [%s]', resource_dict.get('id', 'NO ID Found'))
+                resource_dict = toolkit.get_action("resource_create")(
+                    context.copy(), resource_dict
+                )
+                log.info(
+                    "Created resource with id [%s]",
+                    resource_dict.get("id", "NO ID Found"),
+                )
             except toolkit.ValidationError as e:
-                log.error('Error creating resource: [%s]', e.message)
+                log.error("Error creating resource: [%s]", e.message)
                 self._save_object_error(
-                    'Error creating resource [%s] for identifier [%s] [%r]' % (
-                        package_title, harvest_object.id, e),
-                    harvest_object
+                    "Error creating resource [%s] for identifier [%s] [%r]"
+                    % (package_title, harvest_object.id, e),
+                    harvest_object,
                 )
                 result = False
 
@@ -427,9 +489,11 @@ class CivityHarvester(HarvesterBase):
         :param harvest_job:
         :return:
         """
-        query = model.Session.query(HarvestObject.guid, HarvestObject.package_id). \
-            filter(HarvestObject.current == True). \
-            filter(HarvestObject.harvest_source_id == harvest_job.source.id)
+        query = (
+            model.Session.query(HarvestObject.guid, HarvestObject.package_id)
+            .filter(HarvestObject.current == True)
+            .filter(HarvestObject.harvest_source_id == harvest_job.source.id)
+        )
 
         guid_to_package_id = {}
 
@@ -450,23 +514,28 @@ class CivityHarvester(HarvesterBase):
         try:
             for identifier in self.record_provider.get_record_ids():
                 try:
-                    log.info('Got identifier [%s] from RecordProvider', identifier)
+                    log.info("Got identifier [%s] from RecordProvider", identifier)
                     if identifier is None:
-                        log.error('RecordProvider returned empty identifier [%r], skipping...' % identifier)
+                        log.error(
+                            "RecordProvider returned empty identifier [%r], skipping..."
+                            % identifier
+                        )
                         continue
 
                     guids_in_harvest.add(identifier)
                 except Exception as e:
                     self._save_gather_error(
-                        'Error for identifier [%s] in gather phase: [%r]' % (identifier, e),
-                        harvest_job
+                        "Error for identifier [%s] in gather phase: [%r]"
+                        % (identifier, e),
+                        harvest_job,
                     )
                     continue
         except Exception as e:
-            log.error('Exception: %s' % text_traceback())
+            log.error("Exception: %s" % text_traceback())
             self._save_gather_error(
-                'Error gathering the identifiers from the RecordProvider: [%s]' % str(e),
-                harvest_job
+                "Error gathering the identifiers from the RecordProvider: [%s]"
+                % str(e),
+                harvest_job,
             )
             guids_in_harvest = None
 
@@ -507,18 +576,22 @@ class CivityHarvester(HarvesterBase):
         :return:
         """
         context = {
-            'user': self._get_user_name(),
-            'return_id_only': True,
-            'ignore_auth': True,
+            "user": self._get_user_name(),
+            "return_id_only": True,
+            "ignore_auth": True,
         }
 
         template_package_id = self._get_template_package_id(harvest_config_dict)
         try:
-            result = toolkit.get_action('package_show')(context.copy(), {
-                'id': template_package_id
-            })
+            result = toolkit.get_action("package_show")(
+                context.copy(), {"id": template_package_id}
+            )
         except toolkit.ObjectNotFound as e:
-            log.error('Error looking up template package [%s]: [%s]', template_package_id, e.message)
+            log.error(
+                "Error looking up template package [%s]: [%s]",
+                template_package_id,
+                e.message,
+            )
             result = None
 
         return result
@@ -530,10 +603,10 @@ class CivityHarvester(HarvesterBase):
         ex. {'template_package_id': 'template_for_rotterdam_dataplatform'}
         """
 
-        if 'template_package_id' in harvest_config_dict.keys():
-            result = harvest_config_dict.get('template_package_id', 'template')
+        if "template_package_id" in harvest_config_dict.keys():
+            result = harvest_config_dict.get("template_package_id", "template")
         else:
-            result = 'template'
+            result = "template"
 
         return result
 
@@ -543,7 +616,8 @@ class CivityHarvester(HarvesterBase):
             name = self._gen_new_name(title)
             if not name:
                 raise Exception(
-                    'Could not generate a unique name from the title or the GUID. Please choose a more unique title.')
+                    "Could not generate a unique name from the title or the GUID. Please choose a more unique title."
+                )
         else:
             name = package.name
 

--- a/ckanext/fairdatapoint/harvesters/domain/fair_data_point.py
+++ b/ckanext/fairdatapoint/harvesters/domain/fair_data_point.py
@@ -3,14 +3,14 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-import logging
-import requests
 import encodings
+import logging
+from typing import Union
 
+import requests
 from rdflib import Graph, URIRef
 from rdflib.exceptions import ParserError
-from requests.exceptions import HTTPError, ConnectionError, Timeout, RequestException
-from typing import Union
+from requests.exceptions import ConnectionError, HTTPError, RequestException, Timeout
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +31,9 @@ class FairDataPoint:
         graph = Graph()
         data = self._get_data(path)
         if data is None:
-            log.warning(f"No data was received from FDP {self.fdp_end_point} request {path}")
+            log.warning(
+                f"No data was received from FDP {self.fdp_end_point} request {path}"
+            )
         else:
             try:
                 graph.parse(data=data)
@@ -41,9 +43,7 @@ class FairDataPoint:
 
     @staticmethod
     def _get_data(path: Union[str, URIRef]) -> Union[str, None]:
-        headers = {
-            'Accept': 'text/turtle'
-        }
+        headers = {"Accept": "text/turtle"}
         try:
             response = requests.request("GET", path, headers=headers)
             response.encoding = encodings.utf_8.getregentry().name

--- a/ckanext/fairdatapoint/harvesters/domain/fair_data_point_record_provider.py
+++ b/ckanext/fairdatapoint/harvesters/domain/fair_data_point_record_provider.py
@@ -5,18 +5,15 @@
 
 
 import logging
-
-import requests
-
-from ckanext.fairdatapoint.harvesters.domain.identifier import Identifier
-from ckanext.fairdatapoint.harvesters.domain.fair_data_point import FairDataPoint
-
-from requests import JSONDecodeError, HTTPError
-
-from rdflib import Namespace, URIRef, Literal, DCAT, DCTERMS, Graph, RDF, BNode
-from rdflib.term import Node
 from typing import Dict, Iterable, Union
 
+import requests
+from rdflib import DCAT, DCTERMS, RDF, BNode, Graph, Literal, Namespace, URIRef
+from rdflib.term import Node
+from requests import HTTPError, JSONDecodeError
+
+from ckanext.fairdatapoint.harvesters.domain.fair_data_point import FairDataPoint
+from ckanext.fairdatapoint.harvesters.domain.identifier import Identifier
 
 LDP = Namespace("http://www.w3.org/ns/ldp#")
 VCARD = Namespace("http://www.w3.org/2006/vcard/ns#")

--- a/ckanext/fairdatapoint/harvesters/domain/fair_data_point_record_to_package_converter.py
+++ b/ckanext/fairdatapoint/harvesters/domain/fair_data_point_record_to_package_converter.py
@@ -5,8 +5,8 @@
 
 import logging
 
-from ckanext.fairdatapoint.harvesters.domain.identifier import Identifier
 from ckanext.dcat.processors import RDFParser, RDFParserException
+from ckanext.fairdatapoint.harvesters.domain.identifier import Identifier
 from ckanext.fairdatapoint.processors import FairDataPointRDFParser
 
 log = logging.getLogger(__name__)
@@ -21,14 +21,16 @@ class FairDataPointRecordToPackageConverter:
         parser = FairDataPointRDFParser(profiles=[self.profile])
 
         try:
-            parser.parse(record, _format='ttl')
+            parser.parse(record, _format="ttl")
 
             identifier = Identifier(guid)
-            if identifier.get_id_type() == 'catalog':
+            if identifier.get_id_type() == "catalog":
                 for catalog in parser.catalogs():
                     return catalog
             else:
                 for dataset in parser.datasets():
                     return dataset
         except RDFParserException as e:
-            raise Exception('Error parsing the RDF content [{0}]: {1}'.format(record, e))
+            raise Exception(
+                "Error parsing the RDF content [{0}]: {1}".format(record, e)
+            )

--- a/ckanext/fairdatapoint/harvesters/domain/identifier.py
+++ b/ckanext/fairdatapoint/harvesters/domain/identifier.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-SEPARATOR = ';'
-KEY_VALUE_SEPARATOR = '='
+SEPARATOR = ";"
+KEY_VALUE_SEPARATOR = "="
 
 
 class IdentifierException(Exception):
@@ -38,15 +38,15 @@ class Identifier:
                 result = key_value[index]
             else:
                 raise IdentifierException(
-                    'Unexpected number of parts in key_value [{}]: [{}]',
+                    "Unexpected number of parts in key_value [{}]: [{}]",
                     key_values[1],
-                    len(key_value)
+                    len(key_value),
                 )
         else:
             raise IdentifierException(
-                'Unexpected number of parts in record identifier [{}]: [{}]',
+                "Unexpected number of parts in record identifier [{}]: [{}]",
                 self.guid,
-                len(key_values)
+                len(key_values),
             )
 
         return result

--- a/ckanext/fairdatapoint/harvesters/fair_data_point_civity_harvester.py
+++ b/ckanext/fairdatapoint/harvesters/fair_data_point_civity_harvester.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 import logging
 
+from ckan.plugins import toolkit
+
 from ckanext.fairdatapoint.harvesters.civity_harvester import CivityHarvester
 from ckanext.fairdatapoint.harvesters.domain.fair_data_point_record_provider import (
     FairDataPointRecordProvider,
@@ -11,7 +13,6 @@ from ckanext.fairdatapoint.harvesters.domain.fair_data_point_record_provider imp
 from ckanext.fairdatapoint.harvesters.domain.fair_data_point_record_to_package_converter import (
     FairDataPointRecordToPackageConverter,
 )
-from ckan.plugins import toolkit
 
 PROFILE = "profile"
 HARVEST_CATALOG = "harvest_catalogs"

--- a/ckanext/fairdatapoint/plugin.py
+++ b/ckanext/fairdatapoint/plugin.py
@@ -14,7 +14,6 @@ class FairdatapointPlugin(plugins.SingletonPlugin):
     # IConfigurer
 
     def update_config(self, config_):
-        toolkit.add_template_directory(config_, 'templates')
-        toolkit.add_public_directory(config_, 'public')
-        toolkit.add_resource('fanstatic',
-            'fairdatapoint')
+        toolkit.add_template_directory(config_, "templates")
+        toolkit.add_public_directory(config_, "public")
+        toolkit.add_resource("fanstatic", "fairdatapoint")

--- a/ckanext/fairdatapoint/processors.py
+++ b/ckanext/fairdatapoint/processors.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-from rdflib import RDF, DCAT
+from typing import Dict, Iterable
+
+from rdflib import DCAT, RDF
 from rdflib.term import Node
-from typing import Iterable, Dict
 
 from ckanext.dcat.processors import RDFParser
 
@@ -35,7 +36,9 @@ class FairDataPointRDFParser(RDFParser):
         for catalog_ref in self._catalogs():
             catalog_dict = {}
             for profile_class in self._profiles:
-                profile = profile_class(graph= self.g,compatibility_mode = self.compatibility_mode)
+                profile = profile_class(
+                    graph=self.g, compatibility_mode=self.compatibility_mode
+                )
                 profile.parse_dataset(catalog_dict, catalog_ref)
 
             yield catalog_dict

--- a/ckanext/fairdatapoint/profiles.py
+++ b/ckanext/fairdatapoint/profiles.py
@@ -2,43 +2,54 @@
 # SPDX-FileContributor: 2024 Stichting Health-RI
 #
 # SPDX-License-Identifier: AGPL-3.0-only
-
-from datetime import datetime, timezone
-import re
 import json
 import logging
-
-from ckanext.dcat.profiles import EuropeanDCATAP3Profile
-from ckan.plugins import toolkit
-from ckan import model
-import dateutil.parser as dateparser
-from dateutil.parser import ParserError
+import re
+import urllib.parse
+from datetime import datetime, timezone
 from json import JSONDecodeError
 from typing import Dict, List
-from rdflib import URIRef, Namespace, DCAT, DCTERMS, FOAF
+
+import dateutil.parser as dateparser
+from ckan import model
+from ckan.plugins import toolkit
+from dateutil.parser import ParserError
+from rdflib import DCAT, DCTERMS, FOAF, Namespace, URIRef
+
+from ckanext.dcat.profiles import EuropeanDCATAP3Profile
+from ckanext.fairdatapoint.resolver import PACKAGE_REPLACE_FIELDS
 
 log = logging.getLogger(__name__)
 
 VCARD = Namespace("http://www.w3.org/2006/vcard/ns#")
 
+WIKIDATA_DOMAINS = ["wikidata.org", "www.wikidata.org"]
+
+
 def validate_tags(values_list: List[Dict]) -> List:
     """
     Validates tags strings to contain allowed characters, replaces others with spaces
     """
-    illegal_pattern = re.compile('[^A-Za-z0-9\- _\.]')
+    illegal_pattern = re.compile("[^A-Za-z0-9\- _\.]")
     tags = []
     for item in values_list:
-        tag_value = item['name']
+        tag_value = item["name"]
         if len(tag_value) < 2:
-            log.warning(f'Tag {tag_value} is shorter than 2 characters and will be removed')
+            log.warning(
+                f"Tag {tag_value} is shorter than 2 characters and will be removed"
+            )
         elif len(tag_value) > 100:
-            log.warning(f'Tag {tag_value} is longer than 100 characters and will be removed')
+            log.warning(
+                f"Tag {tag_value} is longer than 100 characters and will be removed"
+            )
         else:
             find_illegal = re.search(illegal_pattern, tag_value)
             if find_illegal:
-                log.warning(f'Tag {tag_value} contains values other than alphanumeric characters, spaces, hyphens, '
-                            f'underscores or dots, they will be replaces with spaces')
-                tag = {'name': re.sub(illegal_pattern, ' ', tag_value)}
+                log.warning(
+                    f"Tag {tag_value} contains values other than alphanumeric characters, spaces, hyphens, "
+                    f"underscores or dots, they will be replaces with spaces"
+                )
+                tag = {"name": re.sub(illegal_pattern, " ", tag_value)}
                 tags.append(tag)
             else:
                 tags.append(item)
@@ -53,12 +64,12 @@ class FAIRDataPointDCATAPProfile(EuropeanDCATAP3Profile):
     def parse_dataset(self, dataset_dict: Dict, dataset_ref: URIRef) -> Dict:
         super(FAIRDataPointDCATAPProfile, self).parse_dataset(dataset_dict, dataset_ref)
 
-        #dataset_dict = self._parse_contact_point(dataset_dict, dataset_ref)
+        # dataset_dict = self._parse_contact_point(dataset_dict, dataset_ref)
         dataset_dict = self._parse_creator(dataset_dict, dataset_ref)
 
-       ## dataset_dict = _convert_extras_to_declared_schema_fields(dataset_dict)
+        ## dataset_dict = _convert_extras_to_declared_schema_fields(dataset_dict)
 
-        dataset_dict['tags'] = validate_tags(dataset_dict['tags'])
+        dataset_dict["tags"] = validate_tags(dataset_dict["tags"])
 
         return dataset_dict
 
@@ -70,10 +81,16 @@ class FAIRDataPointDCATAPProfile(EuropeanDCATAP3Profile):
 
         for agent in self.g.objects(subject, predicate):
             contact = {
-                'uri': (str(agent) if isinstance(agent, URIRef)
-                        else self._get_vcard_property_value(agent, VCARD.hasUID)),
-                'name': self._get_vcard_property_value(agent, VCARD.hasFN, VCARD.fn),
-                'email': self._without_mailto(self._get_vcard_property_value(agent, VCARD.hasEmail))}
+                "uri": (
+                    str(agent)
+                    if isinstance(agent, URIRef)
+                    else self._get_vcard_property_value(agent, VCARD.hasUID)
+                ),
+                "name": self._get_vcard_property_value(agent, VCARD.hasFN, VCARD.fn),
+                "email": self._without_mailto(
+                    self._get_vcard_property_value(agent, VCARD.hasEmail)
+                ),
+            }
 
             contact_list.append(contact)
 
@@ -82,16 +99,23 @@ class FAIRDataPointDCATAPProfile(EuropeanDCATAP3Profile):
     def _parse_contact_point(self, dataset_dict: Dict, dataset_ref: URIRef) -> Dict:
         """
         ckan-dcat extension implies there can be just one contact point and in case a list is provided by source only
-        last value is taken. Besides it never solves uri from a VCard object. This function parses DCAT.contactPoint 
+        last value is taken. Besides it never solves uri from a VCard object. This function parses DCAT.contactPoint
         information to a list of `pontact_point` dictionaries and replaces ckan-dcat values
         """
-        contact_point = self._contact_point_details(subject=dataset_ref, predicate=DCAT.contactPoint)
-        dcat_profile_contact_fields = ['contact_name', 'contact_email', 'contact_uri']
+        contact_point = self._contact_point_details(
+            subject=dataset_ref, predicate=DCAT.contactPoint
+        )
+        dcat_profile_contact_fields = ["contact_name", "contact_email", "contact_uri"]
         if contact_point:
-            dataset_dict['extras'].append({'key': 'contact_point', 'value': contact_point})
+            dataset_dict["extras"].append(
+                {"key": "contact_point", "value": contact_point}
+            )
             # Remove the extras contact_ fields if they were parsed by dcat extension
-            dataset_dict['extras'] = \
-                [item for item in dataset_dict['extras'] if item.get('key') not in dcat_profile_contact_fields]
+            dataset_dict["extras"] = [
+                item
+                for item in dataset_dict["extras"]
+                if item.get("key") not in dcat_profile_contact_fields
+            ]
         return dataset_dict
 
     def _parse_creator(self, dataset_dict: Dict, dataset_ref: URIRef) -> Dict:
@@ -103,20 +127,62 @@ class FAIRDataPointDCATAPProfile(EuropeanDCATAP3Profile):
             creator_name = graph.value(creator_ref, FOAF.name)
 
             if creator_identifier:
-                creator['identifier'] = str(creator_identifier)
+                creator["identifier"] = str(creator_identifier)
             if creator_name:
-                creator['name'] = str(creator_name)
+                creator["name"] = str(creator_name)
             else:
                 # If the creator is a URI, use it as the identifier
                 if isinstance(creator_ref, URIRef):
-                    creator['identifier'] = str(creator_ref)
-                    creator['name'] = str(creator_ref)
+                    creator["identifier"] = str(creator_ref)
+                    creator["name"] = str(creator_ref)
                 else:
-                    creator['name'] = str(creator_ref)
+                    creator["name"] = str(creator_ref)
 
             creators.append(creator)
 
         if len(creators) > 0:
-            dataset_dict['creator'] = creators
+            dataset_dict["creator"] = creators
 
+        return dataset_dict
+
+    @staticmethod
+    def _rewrite_wikidata_url(uri: str) -> str:
+        """This function fixes Wikidata URIs to use references instead of web URI
+
+        It is necessary to fix this for label resolving, as subject in the graph won't match
+        """
+        # URL
+        try:
+            parsed_url = urllib.parse.urlparse(uri)
+
+            if (
+                parsed_url.scheme.startswith("http")
+                and parsed_url.netloc in WIKIDATA_DOMAINS
+                and parsed_url.path.startswith("/wiki/")
+            ):
+                # Find the entity ID; which comes after the /wiki/ part of the URI
+                entity_id = parsed_url.path[len("/wiki/") :]
+                # Make sure it is an actualy valid entity ID, they always start with a letter,
+                # followed by numbers. See https://www.wikidata.org/wiki/Wikidata:Identifiers
+                # Items typically start with a Q, but let's stay flexible.
+                if re.fullmatch("[a-zA-Z]\d+", entity_id):
+                    # All conditions are met. We can rewrite the Wikidata url.
+                    new_url = f"http://www.wikidata.org/entity/{entity_id}"
+
+                    return new_url
+        except ValueError:
+            pass
+
+        return uri
+
+    def _fix_wikidata_uris(self, dataset_dict: dict, fields_list: list[str]):
+        for field in fields_list:
+            value = dataset_dict.get(field)
+            new_value = None
+            if value:
+                if isinstance(value, List):
+                    new_value = [self._rewrite_wikidata_url(uri) for uri in value]
+                else:
+                    new_value = self._rewrite_wikidata_url(value)
+            dataset_dict[field] = new_value
         return dataset_dict

--- a/ckanext/fairdatapoint/resolver.py
+++ b/ckanext/fairdatapoint/resolver.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2024 Stichting Health-RI
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+from __future__ import annotations
+
+import logging
+
+import requests
+from ckan.plugins import toolkit
+from rdflib import RDF, RDFS, SDO, SKOS, Graph, URIRef
+
+log = logging.getLogger(__name__)
+
+PACKAGE_REPLACE_FIELDS = [
+    "access_rights",
+    "conforms_to",
+    "has_version",
+    "language",
+    "spatial_uri",
+    "theme",
+]
+
+
+class label_resolver:
+    """Generic label resolver class
+
+    This class implements a generic label resolver. It consists of three functions:
+    1. load_graph
+    2. literal_dict_from_graph
+    3. load_and_translate_uri
+
+    The functions are made for the generic case: assuming the subject URI is resolvable and will
+    return an RDF document when accessed using content negotiation. This can work for some of the
+    European labels (HVD themes for example) and also for Wikidata.
+
+    Some ontologies (e.g. SNOMED-CT) don't have resolvable URIs, in that case an OWL ontology would
+    have to be loaded first. For these cases, all you'd have to do is override the load_graph
+    function in a subclass to point to the OWL ontology to load. There you could also implement
+    some caching to make sure it doens't keep trying to load 1 million triples for every label.
+    """
+
+    g = Graph()
+
+    def literal_dict_from_graph(self, subject: str | URIRef) -> dict:
+        """Turns a Graph into a dictionary with key: language, value: label
+
+        This function traverses Graph g to find the labels for a given subject.
+        It looks at the following namespaces in order:
+            1. Schema.org name
+            2. RDF-scheme label
+            3. SKOS prefLabel
+
+        All found labels and languages are stored in a dictionary. See this example for the format:
+        ```
+        {
+          "nl": "Albus Perkamentus",
+          "en": "Albus Dumbledore"
+        }
+        ```
+
+        Literals without a language tag are stored in a `None` key. If there is multiple Literals
+        without a language, it is undefined behavior which one will actually end up in the
+        dictionary as the order of graphs is, by their nature, undefined.
+
+        Parameters
+        ----------
+        subject : str | URIRef
+            subject for which the label is to be extracted
+
+        Returns
+        -------
+        dict
+            Dictionary containing labels with language as key, localized label as value
+        """
+        lang_dict = dict()
+        if not isinstance(subject, URIRef):
+            subject = URIRef(subject)
+
+        # I am aware the dictionary gets overwritten. I am assuming SKOS.prefLabel is the most
+        # "authortive" one and therefore it will overwrite the preceding labels.
+        for label_predicate in [SDO.name, RDFS.label, SKOS.prefLabel]:
+            if (subject, label_predicate, None) in self.g:
+                # Check if it contains label_predicate for the subject
+                for x in self.g.objects(
+                    subject=subject,
+                    predicate=label_predicate,
+                ):
+                    lang_dict[x.language] = x.value
+
+        return lang_dict
+
+    def load_graph(self, uri: str | URIRef, empty_graph: bool = False) -> Graph:
+        """Loads graph into the class located at a URI into the class
+
+        Parameters
+        ----------
+        uri : str | URIRef
+            URI of graph to load
+        empty_graph : bool, optional
+            Empty current graph when loading, by default False
+
+        Returns
+        -------
+        Graph
+            Loaded Graph
+        """
+        if empty_graph:
+            del self.g
+            self.g = Graph()
+        self.g.parse(uri)
+
+        return self.g
+
+    def load_and_translate_uri(self, subject_uri: str | URIRef) -> list[dict[str, str]]:
+        """Loads the RDF graph for a given subject, extracts labels a
+
+        Parameters
+        ----------
+        subject_uri : str | URIRef
+            Subject URI that the labels need to be extracted for
+
+        Returns
+        -------
+        list[dict[str, str]]
+            List of dictionaries in the format of CKAN function `term_translation_update_many`
+        """
+        self.load_graph(subject_uri)
+        translation_dict = self.literal_dict_from_graph(subject_uri)
+
+        ckan_translation_list = []
+
+        """
+        Now turn the dictionary into CKAN format
+        It should be as follows:
+
+        Parameters:
+        term (string) - the term to be translated, in the original language, e.g. 'romantic novel'
+        term_translation (string) - the translation of the term, e.g. 'Liebesroman'
+        lang_code (string) - the language code of the translation, e.g. 'de'
+        """
+
+        for language, label in translation_dict.items():
+            if language:
+                ckan_translation_list.append(
+                    {
+                        "term": str(subject_uri),
+                        "term_translation": label,
+                        "lang_code": language,
+                    }
+                )
+            else:
+                ckan_translation_list.append(
+                    {
+                        "term": "en",
+                        "term_translation": label,
+                        "lang_code": language,
+                    }
+                )
+
+        return ckan_translation_list
+
+
+def get_list_unresolved_terms(terms: list[str]) -> list[str]:
+    """This function gets a list of terms not known by CKAN, based on an input list
+
+    Parameters
+    ----------
+    terms : list[str]
+        List of labels that harvested, that need to be checked if they are resolved
+
+    Returns
+    -------
+    list[str]
+        List containing the labels that are resolved
+    """
+    term_set = set(terms)
+
+    # TODO language codes should be dynamic
+    translation_table = toolkit.get_action("term_translation_show")(
+        {}, {"terms": term_set, "lang_codes": ("en", "nl")}
+    )
+
+    known_terms = set(x["term"] for x in translation_table)
+    unknown_terms = term_set - known_terms
+
+    return list(unknown_terms)

--- a/ckanext/fairdatapoint/tests/test_resolver.py
+++ b/ckanext/fairdatapoint/tests/test_resolver.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Stichting Health-RI
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+import pytest
+import requests_mock
+
+# TODO


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 Stichting Health-RI -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:** 
  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

This PR implements a label resolver in the harvester import stage.

The scope of it is quite limited for now: it attempts to resolve any URI it finds in the six fields that are translated in the gdi userportal extension plugin (fields are hardcoded for now, same as in the other plugin). If it resolves and returns something RDFlib can understand (e.g. if the URI exists and supports content negotiation), it digs through the graph to find translations. Currently three properties are understood: SKOS prefLabel, RDF Scheme Label, and Schema.org name.

There is some logic in there to prevent too much hammering of a database, namely only unresolved labels are queried and duplicates in the same dataset are filtered out. However, if multiple datasets refer to the same label, it has no problems hammering the external URI every single time on every single (re-)harvest.

- **Context:**
Right now, labels are very much hardcoded.


- **Changes:**
There is a seperate commit in here to do a whole bunch of linting. My IDE does it automatically and it is time to conform to PEP8. All functional stuff is in separate commits.

- **Testing:**
Unit testing to be implemented (that's why this PR is a draft). Testing performed against a few FDPs.


- **Screenshots (if applicable):**
See front-end.

- **Additional Information:**
N/A

- **Checklist:**
  - `[X]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[X]` I have performed self-review of my own code and corrected any misspellings.
  - `[X]` I have made corresponding changes to the documentation (if applicable).
  - `[X]` My changes generate no new warnings or errors.
  - `[ ]` *TBD* I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` *TBD* New and existing unit tests pass locally with my changes (*existing tests pass*)