### PR TITLE
feat(dataseries) Be able to store dataseries via FDP route

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,8 @@ jobs:
         # Scheming (Civity fork)
         pip install -e 'git+https://github.com/CivityNL/ckanext-scheming.git@3.0.0-civity-1#egg=ckanext-scheming[requirements]'
 
-        git clone https://github.com/hcvdwerf/ckanext-dcat
-        cd ckanext-dcat
+        git clone https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat
+        cd gdi-userportal-ckanext-dcat
         git checkout support-RDF-dataseries-serialisation
         pip install -e .
         pip install -r requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
 
         git clone https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat
         cd gdi-userportal-ckanext-dcat
-        git checkout support-RDF-dataseries-serialisation
+        git checkout master
         pip install -e .
         pip install -r requirements.txt
     - name: Setup extension

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,16 +38,28 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Install requirements
+    - name: Install requirements (common)
       run: |
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
-        pip install --upgrade pytest-rerunfailures
-        pip install -e 'git+https://github.com/CivityNL/ckanext-scheming.git@release-3.0.0-civity-1#egg=ckanext-scheming[requirements]'
-        pip install -e 'git+https://github.com/ckan/ckanext-harvest.git@v1.6.1#egg=ckanext-harvest[requirements]'
-        pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/v1.6.1/requirements.txt
-        pip install ckanext-dcat==2.3.0
-        python3 setup.py develop
+        pip install -e .
+    - name: Setup CKAN extensions (harvest, scheming, dcat)
+      run: |
+        # Harvest v1.6.1 from GitHub
+        git clone https://github.com/ckan/ckanext-harvest
+        cd ckanext-harvest
+        git checkout tags/v1.6.1
+        pip install -e .
+        pip install -r requirements.txt
+
+        # Scheming (Civity fork)
+        pip install -e 'git+https://github.com/CivityNL/ckanext-scheming.git@3.0.0-civity-1#egg=ckanext-scheming[requirements]'
+
+        git clone https://github.com/hcvdwerf/ckanext-dcat
+        cd ckanext-dcat
+        git checkout support-RDF-dataseries-serialisation
+        pip install -e .
+        pip install -r requirements.txt
     - name: Setup extension
       run: |
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini

--- a/ckanext/fairdatapoint/harvesters/civity_harvester.py
+++ b/ckanext/fairdatapoint/harvesters/civity_harvester.py
@@ -328,6 +328,7 @@ class CivityHarvester(HarvesterBase):
                 package_dict = self.record_to_package_converter.record_to_package(
                     harvest_object.guid, str(harvest_object.content)
                 )
+            package_dict.setdefault("extras", []).append({"key": "guid", "value": identifier_harvest_object.get_id_value()})
         except Exception as e:
             logger.error(
                 "Error converting record to package for identifier [%s] [%r]"

--- a/ckanext/fairdatapoint/harvesters/domain/fair_data_point_record_provider.py
+++ b/ckanext/fairdatapoint/harvesters/domain/fair_data_point_record_provider.py
@@ -41,6 +41,10 @@ class FairDataPointRecordProvider:
                 identifier = Identifier("")
                 identifier.add("dataset", str(fdp_record.url))
                 result[identifier.guid] = fdp_record.url
+            elif fdp_record.is_dataseries():
+                identifier = Identifier("")
+                identifier.add("dataseries", str(fdp_record.url))
+                result[identifier.guid] = fdp_record.url
         return result.keys()
 
     def get_record_by_id(self, guid: str) -> str:

--- a/ckanext/fairdatapoint/harvesters/domain/fair_data_point_record_to_package_converter.py
+++ b/ckanext/fairdatapoint/harvesters/domain/fair_data_point_record_to_package_converter.py
@@ -40,4 +40,4 @@ class FairDataPointRecordToPackageConverter:
         except RDFParserException as e:
             raise Exception(
                 f"Error parsing the RDF content [{record}]: {e}"
-            )
+            ) from e

--- a/ckanext/fairdatapoint/harvesters/domain/fair_data_point_record_to_package_converter.py
+++ b/ckanext/fairdatapoint/harvesters/domain/fair_data_point_record_to_package_converter.py
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import logging
+from typing import Any, Dict, Optional
 
-from ckanext.dcat.processors import RDFParser, RDFParserException
+from ckanext.dcat.processors import RDFParserException
 from ckanext.fairdatapoint.harvesters.domain.identifier import Identifier
 from ckanext.fairdatapoint.processors import FairDataPointRDFParser
 
@@ -17,7 +18,7 @@ class FairDataPointRecordToPackageConverter:
     def __init__(self, profile: str):
         self.profile = profile
 
-    def record_to_package(self, guid: str, record: str, series_mapping=None):
+    def record_to_package(self, guid: str, record: str, series_mapping=None) -> Optional[Dict[str, Any]]:
         parser = FairDataPointRDFParser(profiles=[self.profile])
 
         try:
@@ -32,7 +33,7 @@ class FairDataPointRecordToPackageConverter:
             else:
                 items = list(parser.datasets(series_mapping=series_mapping))
 
-            if not items:
+            if not items or len(items) < 1:
                 log.warning("No %s found in RDF", datatype)
                 return None  # Returning None instead of False for clarity
 

--- a/ckanext/fairdatapoint/harvesters/domain/fdp_record.py
+++ b/ckanext/fairdatapoint/harvesters/domain/fdp_record.py
@@ -26,3 +26,4 @@ class FdpRecord:
 
     def is_dataseries(self):
         return (URIRef(self.url), RDF.type, DCAT.DatasetSeries) in self._graph
+    

--- a/ckanext/fairdatapoint/harvesters/domain/fdp_record.py
+++ b/ckanext/fairdatapoint/harvesters/domain/fdp_record.py
@@ -23,3 +23,6 @@ class FdpRecord:
 
     def is_dataset(self):
         return (URIRef(self.url), RDF.type, DCAT.Dataset) in self._graph
+
+    def is_dataseries(self):
+        return (URIRef(self.url), RDF.type, DCAT.DatasetSeries) in self._graph

--- a/ckanext/fairdatapoint/tests/test_data/root_fdp_response.ttl
+++ b/ckanext/fairdatapoint/tests/test_data/root_fdp_response.ttl
@@ -7,15 +7,23 @@
 @prefix ldp: <http://www.w3.org/ns/ldp#> .
 @prefix ex: <http://example.org/> .
 
+########### Catalog ###########
 ex:Catalog1 a ldp:DirectContainer, dcat:Catalog ;
     dct:title "Catalog of Datasets"@en ;
     ldp:membershipResource ex:Catalog1 ;
     ldp:hasMemberRelation dcat:dataset ;
+    ldp:contains ex:DatasetSeries1 .
+
+########### Dataset Series as LDP Container ###########
+ex:DatasetSeries1 a ldp:DirectContainer, dcat:DatasetSeries ;
+    dct:title "Genomic Studies over Time"@en ;
+    dct:description "A series of genomic datasets collected across multiple years and studies."@en ;
+    ldp:membershipResource ex:DatasetSeries1 ;
+    ldp:hasMemberRelation dcat:hasPart ;
     ldp:contains ex:Dataset1 .
 
-# Dataset under Dataseries
+########### Dataset belonging to the series ###########
 ex:Dataset1 a dcat:Dataset ;
-    dct:title "Genomic Variation Dataset"@en ;
-    dct:description "Genomic data collected from multiple populations."@en .
-
-
+    dct:title "Genomic Variation Dataset 2023"@en ;
+    dct:description "Genomic data collected from multiple populations in 2023."@en ;
+    dcat:inSeries ex:DatasetSeries1 .

--- a/ckanext/fairdatapoint/tests/test_processors.py
+++ b/ckanext/fairdatapoint/tests/test_processors.py
@@ -36,7 +36,7 @@ class TestProcessors:
         data = Graph().parse(Path(TEST_DATA_DIRECTORY, "fdp_catalog.ttl")).serialize()
         fdp_record_to_package.record_to_package(
             guid="catalog=https://fair.healthinformationportal.eu/catalog/1c75c2c9-d2cc-44cb-aaa8-cf8c11515c8d",
-            record=data)
+            record=data, series_mapping=None)
         assert parser_catalogs.called
 
     def test_fdp_record_converter_dataset_dict(self):
@@ -46,7 +46,7 @@ class TestProcessors:
             guid="catalog=https://covid19initiatives.health-ri.nl/p/ProjectOverview?focusarea="
                  "http://purl.org/zonmw/generic/10006;"
                  "dataset=https://covid19initiatives.health-ri.nl/p/Project/27866022694497978",
-            record=data)
+            record=data, series_mapping=None)
         expected_dataset = dict(extras=[], uri="https://covid19initiatives.health-ri.nl/p/Project/27866022694497978",
                                 resources=[], title="COVID-NL cohort MUMC+",
                                 notes="Clinical data of MUMC COVID-NL cohort", tags=[],
@@ -64,7 +64,8 @@ class TestProcessors:
         data = Graph().parse(Path(TEST_DATA_DIRECTORY, "fdp_catalog.ttl")).serialize()
         actual = fdp_record_to_package.record_to_package(
             guid="catalog=https://fair.healthinformationportal.eu/catalog/1c75c2c9-d2cc-44cb-aaa8-cf8c11515c8d",
-            record=data)
+            record=data, series_mapping=None)
+
 
         expected = {
             "uri": "https://fair.healthinformationportal.eu/catalog/1c75c2c9-d2cc-44cb-aaa8-cf8c11515c8d",

--- a/ckanext/fairdatapoint/tests/test_profiles.py
+++ b/ckanext/fairdatapoint/tests/test_profiles.py
@@ -38,7 +38,7 @@ def test_parse_dataset():
     actual = fdp_record_to_package.record_to_package(
         guid="catalog=https://health-ri.sandbox.semlab-leiden.nl/catalog/5c85cb9f-be4a-406c-ab0a-287fa787caa0;"
              "dataset=https://health-ri.sandbox.semlab-leiden.nl/dataset/d9956191-1aff-4181-ac8b-16b829135ed5",
-        record=data)
+        record=data, series_mapping=None)
     expected = {
         'extras': [],
         'resources': [

--- a/ckanext/fairdatapoint/tests/test_record_provider.py
+++ b/ckanext/fairdatapoint/tests/test_record_provider.py
@@ -33,7 +33,7 @@ class TestRecordProvider:
             (
                     Path(TEST_DATA_DIRECTORY, "root_fdp_response.ttl"),
                     {
-                        'dataset=http://example.org/Dataset1',
+                        'dataseries=http://example.org/DatasetSeries1', 'dataset=http://example.org/Dataset1'
                     }
             ),
             (
@@ -62,6 +62,7 @@ class TestRecordProvider:
             (
                     Path(TEST_DATA_DIRECTORY, "fdp_multiple_parents.ttl"),
                     {
+                        'dataseries=http://example.org/Dataseries1',
                         'dataset=http://example.org/Dataset1'
                     },
             )


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 Stichting Health-RI -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:** 
  - `[ ]` A brief, descriptive title for the changes.

- **Description:**
  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**
  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**
  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**
  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**
  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**
  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Enable full support for dataset series in the FDP harvester by detecting, parsing, and storing dataseries alongside datasets, while maintaining harvest order and passing series information through to package conversion.

New Features:
- Detect and include dataseries records in the record provider and RDF parser.
- Extend the record_to_package converter to accept and apply a series_mapping when converting datasets.
- Sort harvest GUIDs so that dataseries are processed before datasets.

Enhancements:
- Modify import_stage to build and pass a series_mapping for datasets and always append the GUID as an extra.
- Add Identifier usage to distinguish between dataset and dataseries during import.

CI:
- Revise GitHub Actions workflow to clone and pip install ckanext-harvest, scheming, and dcat extensions instead of direct requirements.

Tests:
- Update fixtures and record_to_package calls to accept a series_mapping parameter.
- Add a test to verify linking datasets to existing dataseries.
- Adjust existing tests for dataseries support and import_stage changes.