### PR TITLE
chore: update the vulnerable sonarcloud version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Install unzip
       run: apt-get update && apt-get install -y unzip
     - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@v5
+      uses: SonarSource/sonarqube-scan-action@v5.3.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Update the SonarCloud Scan step in the CI workflow to use SonarSource/sonarqube-scan-action@v5.3.1 instead of the vulnerable v5

https://community.sonarsource.com/t/security-advisory-sonarqube-scanner-github-action/147696/13

## Summary by Sourcery

CI:
- Update SonarCloud Scan step to SonarSource/sonarqube-scan-action@v5.3.1 to address security vulnerability